### PR TITLE
DESCW-3092 fix reference in workflow so it runs on all branches

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,10 +3,7 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches:
-      - '**'
   workflow_dispatch:
-
 jobs:
   trigger:
     uses: bcgov/des-git-workflows/.github/workflows/linting.yml@main


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/linting.yml` file. The change removes the specification of branches under the `pull_request` trigger, simplifying the workflow configuration.